### PR TITLE
RECORD_STARTX等defineし、switch caseでレコードタイプごとに表示分けした。その画面はRECボタンにした。

### DIFF
--- a/src/screens/screen_standby.cpp
+++ b/src/screens/screen_standby.cpp
@@ -27,54 +27,127 @@ void showStandbyScreen(const AppState &state) {
     // テキストを中央揃えするための Datum 設定
     M5.Lcd.setTextDatum(MC_DATUM); // 中心を基準にテキストを描画
 
-    // 1つ目の四角
-    int x1 = STARTX;
-    M5.Lcd.drawRect(x1, STARTY, RECTWIDTH, RECTHEIGHT, BLACK);
-    M5.Lcd.drawString("朝食", x1 + RECTWIDTH/2, STARTY + RECTHEIGHT/2);
+    switch (state.selectedRecordType)
+    {
+    case MEAL:{
+        // 1つ目の四角
+        int x1 = MEALTIME_STARTX;
+        M5.Lcd.drawRect(x1, MEALTIME_STARTY, MEALTIME_RECTWIDTH, MEALTIME_RECTHEIGHT, BLACK);
+        M5.Lcd.drawString("朝食", x1 + MEALTIME_RECTWIDTH/2, MEALTIME_STARTY + MEALTIME_RECTHEIGHT/2);
 
-    // 2つ目の四角
-    int x2 = x1 + RECTWIDTH + GAP;
-    M5.Lcd.drawRect(x2, STARTY, RECTWIDTH, RECTHEIGHT, BLACK);
-    M5.Lcd.drawString("昼食", x2 + RECTWIDTH/2, STARTY + RECTHEIGHT/2);
+        // 2つ目の四角
+        int x2 = x1 + MEALTIME_RECTWIDTH + GAP;
+        M5.Lcd.drawRect(x2, MEALTIME_STARTY, MEALTIME_RECTWIDTH, MEALTIME_RECTHEIGHT, BLACK);
+        M5.Lcd.drawString("昼食", x2 + MEALTIME_RECTWIDTH/2, MEALTIME_STARTY + MEALTIME_RECTHEIGHT/2);
 
-    // 3つ目の四角
-    int x3 = x2 + RECTWIDTH + GAP;
-    M5.Lcd.drawRect(x3, STARTY, RECTWIDTH, RECTHEIGHT, BLACK);
-    M5.Lcd.drawString("夕食", x3 + RECTWIDTH/2, STARTY + RECTHEIGHT/2);
+        // 3つ目の四角
+        int x3 = x2 + MEALTIME_RECTWIDTH + GAP;
+        M5.Lcd.drawRect(x3, MEALTIME_STARTY, MEALTIME_RECTWIDTH, MEALTIME_RECTHEIGHT, BLACK);
+        M5.Lcd.drawString("夕食", x3 + MEALTIME_RECTWIDTH/2, MEALTIME_STARTY + MEALTIME_RECTHEIGHT/2);
+        break;
+    }
+    
+    case DRINK:{
+        M5.Lcd.drawRect(RECORD_STARTX, RECORD_STARTY, RECORD_RECTWIDTH, RECORD_RECTHEIGHT, BLACK);
+        M5.Lcd.drawString("REC",RECORD_STARTX + RECORD_RECTWIDTH/2, RECORD_STARTY + RECORD_RECTHEIGHT/2);
+        break;
+    }
 
+    case EXCRETION:{
+        M5.Lcd.drawRect(RECORD_STARTX, RECORD_STARTY, RECORD_RECTWIDTH, RECORD_RECTHEIGHT, BLACK);
+        M5.Lcd.drawString("REC",RECORD_STARTX + RECORD_RECTWIDTH/2, RECORD_STARTY + RECORD_RECTHEIGHT/2);
+        break;
+    }
 
+    case BATH:{
+        M5.Lcd.drawRect(RECORD_STARTX, RECORD_STARTY, RECORD_RECTWIDTH, RECORD_RECTHEIGHT, BLACK);
+        M5.Lcd.drawString("REC",RECORD_STARTX + RECORD_RECTWIDTH/2, RECORD_STARTY + RECORD_RECTHEIGHT/2);
+        break;
+    }
+
+    case EVERYDAY:{
+        M5.Lcd.drawRect(RECORD_STARTX, RECORD_STARTY, RECORD_RECTWIDTH, RECORD_RECTHEIGHT, BLACK);
+        M5.Lcd.drawString("REC",RECORD_STARTX + RECORD_RECTWIDTH/2, RECORD_STARTY + RECORD_RECTHEIGHT/2);
+        break;
+    }
+    default:{
+        Serial.println("error::RECORDTYPE is undefined");
+        break;
+    }
+    }
     showFooterBar(state);
 }
 
 bool handleRecBtnTouch(const TouchPoint_t &touch, AppState &state) {
-    // ボタン共通のサイズと配置
+    switch (state.selectedRecordType)
+    {
+    case MEAL:{
+        // 各ボタンの範囲
+        int x1 = MEALTIME_STARTX;
+        int x2 = x1 + MEALTIME_RECTWIDTH + GAP;
+        int x3 = x2 + MEALTIME_RECTWIDTH + GAP;
 
-    // 各ボタンの範囲
-    int x1 = STARTX;
-    int x2 = x1 + RECTWIDTH + GAP;
-    int x3 = x2 + RECTWIDTH + GAP;
+        // REC1 の判定
+        if (touch.x > x1 && touch.x < x1 + MEALTIME_RECTWIDTH &&
+            touch.y > MEALTIME_STARTY && touch.y < MEALTIME_STARTY + MEALTIME_RECTHEIGHT) {
+            state.mealTime = BREAKFAST;
+            return true;
+        }
 
-    // REC1 の判定
-    if (touch.x > x1 && touch.x < x1 + RECTWIDTH &&
-        touch.y > STARTY && touch.y < STARTY + RECTHEIGHT) {
-        state.mealTime = BREAKFAST;
-        return true;
+        // REC2 の判定
+        if (touch.x > x2 && touch.x < x2 + MEALTIME_RECTWIDTH &&
+            touch.y > MEALTIME_STARTY && touch.y < MEALTIME_STARTY + MEALTIME_RECTHEIGHT) {
+            state.mealTime = LUNCH;
+            return true;
+        }
+
+        // REC3 の判定
+        if (touch.x > x3 && touch.x < x3 + MEALTIME_RECTWIDTH &&
+            touch.y > MEALTIME_STARTY && touch.y < MEALTIME_STARTY + MEALTIME_RECTHEIGHT) {
+            state.mealTime = DINNER;
+            return true;
+        }
+
+        // どのボタンも押されていない
+        return false;
+    }
+    
+    case DRINK:{
+       if (touch.x > RECORD_STARTX && touch.x < RECORD_STARTX + RECORD_RECTWIDTH &&
+           touch.y > RECORD_STARTY && touch.y < RECORD_STARTY + RECORD_RECTHEIGHT){
+           return true;
+           }
+        return false;
     }
 
-    // REC2 の判定
-    if (touch.x > x2 && touch.x < x2 + RECTWIDTH &&
-        touch.y > STARTY && touch.y < STARTY + RECTHEIGHT) {
-        state.mealTime = LUNCH;
-        return true;
+    case EXCRETION:{
+        if (touch.x > RECORD_STARTX && touch.x < RECORD_STARTX + RECORD_RECTWIDTH &&
+            touch.y > RECORD_STARTY && touch.y < RECORD_STARTY + RECORD_RECTHEIGHT){
+            return true;
+            }
+        return false;
     }
 
-    // REC3 の判定
-    if (touch.x > x3 && touch.x < x3 + RECTWIDTH &&
-        touch.y > STARTY && touch.y < STARTY + RECTHEIGHT) {
-        state.mealTime = DINNER;
-        return true;
+    case BATH:{
+        if (touch.x > RECORD_STARTX && touch.x < RECORD_STARTX + RECORD_RECTWIDTH &&
+            touch.y > RECORD_STARTY && touch.y < RECORD_STARTY + RECORD_RECTHEIGHT){
+            return true;
+            }
+        return false;
     }
 
-    // どのボタンも押されていない
-    return false;
+    case EVERYDAY:{
+        if (touch.x > RECORD_STARTX && touch.x < RECORD_STARTX + RECORD_RECTWIDTH &&
+            touch.y > RECORD_STARTY && touch.y < RECORD_STARTY + RECORD_RECTHEIGHT){
+            return true;
+            }
+        return false;
+    }
+    default:{
+        Serial.println("error::RECORDTYPE is undefined");
+        return false;
+    }
+    }
+
+    
 }

--- a/src/screens/screen_standby.h
+++ b/src/screens/screen_standby.h
@@ -7,11 +7,15 @@
 #include "../ui/header.h"
 #include "../ui/footer.h"
 
-#define RECTWIDTH 80     // 幅
-#define RECTHEIGHT 80     // 高さ
+#define MEALTIME_RECTWIDTH 80     // 幅
+#define MEALTIME_RECTHEIGHT 80     // 高さ
 #define GAP 10     // 四角同士の間隔
-#define STARTX 40     // 一番左の四角の描画開始X座標
-#define STARTY 80     // 四角の描画開始Y座標
+#define MEALTIME_STARTX 40     // 一番左の四角の描画開始X座標
+#define MEALTIME_STARTY 80     // 四角の描画開始Y座標
+#define RECORD_RECTWIDTH  120
+#define RECORD_RECTHEIGHT  80
+#define RECORD_STARTX  100
+#define RECORD_STARTY  80
 
 void showStandbyScreen(const AppState &state);
 bool handleRecBtnTouch(const TouchPoint_t &touch, AppState &state);


### PR DESCRIPTION
## 概要


## 関連タスク
Close # (required)

## やったこと
`screen_standby.cpp`に変更を加えた。
`switch case`でレコードタイプごとに画面表示を場合分け
`RECORD_STARTX`など、食事記録以外の場合の `standby`画面の定数を定義
　　その場合は中心にRECボタンを配置

## やらないこと


## レビュー事項
-

## 補足 参考情報


