### PR TITLE
WifiとSDカードの確認をロード画面に表示させるようにした

### DIFF
--- a/include/main.h
+++ b/include/main.h
@@ -30,7 +30,8 @@ enum Screen {
     FINAL_SCREEN,
     TRANSCRIPTION,
     EXTRACT,
-    RECORD_TYPE_PICKER
+    RECORD_TYPE_PICKER,
+    ROADING
 };
 
 enum RecordType{

--- a/src/screens/screen_roading.cpp
+++ b/src/screens/screen_roading.cpp
@@ -1,0 +1,28 @@
+#include "screen_roading.h"
+#include <FS.h>
+#include <SD.h>
+
+void showRoadingScreen(const AppState &state){
+    M5.Lcd.setRotation(1);
+
+    // 画面全体を白で塗りつぶし
+    M5.Lcd.fillScreen(WHITE);
+  
+    // テキスト色を紺色に設定（背景は白）
+    // NAVY が定義されていない場合は 0x001F (青) や 0x780F (紺寄り) などを使ってください
+    M5.Lcd.setTextColor(NAVY, WHITE);
+  
+    // テキストの基準位置を「中央」に設定
+    M5.Lcd.setTextDatum(MC_DATUM);
+
+    M5.Lcd.setTextSize(2);
+
+  
+    // ディスプレイ中央に「ながらかいご」を描画
+    M5.Lcd.drawString("ながらかいご", M5.Lcd.width() / 2, M5.Lcd.height() / 2);
+
+
+    M5.Lcd.setTextSize(1);
+
+}
+

--- a/src/screens/screen_roading.h
+++ b/src/screens/screen_roading.h
@@ -1,0 +1,10 @@
+#ifndef SCREEN_ROADING_H
+#define SCREEN_ROADING_H
+
+#include <main.h>
+#include <M5Core2.h>
+
+void showRoadingScreen(const AppState &state);
+
+
+#endif

--- a/src/setup.cpp
+++ b/src/setup.cpp
@@ -10,6 +10,7 @@
 #include <WiFiClientSecure.h>
 #include "services/api/residents.h"
 #include <vector>
+#include "screens/screen_roading.h"
 
 AppState appState;
 
@@ -34,6 +35,8 @@ void initializeSystem() {
     Serial.println("SD Card init failed!");
     return;
   }
+
+  showRoadingScreen(appState);
   //Wi-Fi接続
   connectToWiFi();
   client.setInsecure();  // SSL 証明書の検証を無効化

--- a/src/setup.cpp
+++ b/src/setup.cpp
@@ -28,6 +28,8 @@ void initializeSystem() {
 
   appState.currentScreen = RESIDENT_PICKER;
   appState.screenHistory.push(appState.currentScreen);
+
+  showRoadingScreen(appState);
   
 
   //SDカード初期化
@@ -35,8 +37,6 @@ void initializeSystem() {
     Serial.println("SD Card init failed!");
     return;
   }
-
-  showRoadingScreen(appState);
   //Wi-Fi接続
   connectToWiFi();
   client.setInsecure();  // SSL 証明書の検証を無効化

--- a/src/setup.cpp
+++ b/src/setup.cpp
@@ -35,11 +35,14 @@ void initializeSystem() {
   //SDカード初期化
   if (!initializeSD()) {
     Serial.println("SD Card init failed!");
+    M5.Lcd.drawString("メモリーカードが確認できませんでした", M5.Lcd.width() / 2, M5.Lcd.height() * 3 / 4);
     return;
   }
+  M5.Lcd.drawString("メモリーカードを確認しました", M5.Lcd.width() / 2, M5.Lcd.height() * 3 / 4);
   //Wi-Fi接続
   connectToWiFi();
   client.setInsecure();  // SSL 証明書の検証を無効化
+  M5.Lcd.setTextDatum(MC_DATUM);
   //ログイン
   String loginResponse = api.loginToApi(API_LOGIN_ID, API_PASSWORD);
   Serial.println("Login Response:");

--- a/src/system/wifi_manager.cpp
+++ b/src/system/wifi_manager.cpp
@@ -1,14 +1,19 @@
 #include "wifi_manager.h"
 #include <WiFi.h>
 #include "config.h"
+#include <M5Core2.h>
 
 const char* ssid = WIFI_SSID;
 const char* password = WIFI_PASSWORD;
 
 void connectToWiFi() {
     WiFi.begin(ssid, password);
+    M5.Lcd.fillRect(0, 140, 340, 120, WHITE);
+    M5.Lcd.drawString("ネットワーク通信中", M5.Lcd.width() / 2, M5.Lcd.height() * 3 / 4);
     while (WiFi.status() != WL_CONNECTED) {
         delay(500);
     }
+    M5.Lcd.fillRect(0, 140, 340, 120, WHITE);
     Serial.println("WiFi Connected!");
+    M5.Lcd.drawString("ネットワーク通信成功", M5.Lcd.width() / 2, M5.Lcd.height() * 3 / 4);
 }


### PR DESCRIPTION
## 概要


## 関連タスク
Close #97  (required)

## やったこと
wifi_managerのconnectToWiFi()に接続中と接続完了時に、画面に接続完了や接続中と出す処理を組み込んだ
setup()でSDカードのイニシャライズを行う場面で、SD.begin()ができているかどうか（SDカードが存在するか）を画面に表示させる処理を組み込んだ。

## やらないこと


## レビュー事項
-

## 補足 参考情報


