### PR TITLE
WifiClientSecureの統一、SDカードエラーの修正

### DIFF
--- a/src/services/api/general.cpp
+++ b/src/services/api/general.cpp
@@ -3,16 +3,18 @@
 #include <WiFiClientSecure.h>
 #include <HTTPClient.h>
 
+extern WiFiClientSecure client;
 
 // HTTP POST リクエストの共通処理
 String httpPostJson(MyApi& api, const String& endpoint, const String& jsonBody, const String& token) {
-    WiFiClientSecure client;
+    //WiFiClientSecure client;
     client.setInsecure();
     HTTPClient http;
     String url = api.getBaseUrl() + endpoint;
     String payload;
   
     if (http.begin(client, url)) {
+      http.setTimeout(20000); 
       http.addHeader("Content-Type", "application/json");
       if (token.length() > 0) {
         http.addHeader("Authorization", "Bearer " + token);
@@ -34,13 +36,14 @@ String httpPostJson(MyApi& api, const String& endpoint, const String& jsonBody, 
   
   // HTTP GET リクエストの共通処理
   String httpGet(MyApi& api, const String& endpoint, const String& token) {
-    WiFiClientSecure client;
+    //WiFiClientSecure client;
     client.setInsecure();
     HTTPClient http;
     String url = api.getBaseUrl() + endpoint;
     String payload;
   
     if (http.begin(client, url)) {
+      http.setTimeout(20000);
       if (token.length() > 0) {
         http.addHeader("Authorization", "Bearer " + token);
       }
@@ -61,14 +64,16 @@ String httpPostJson(MyApi& api, const String& endpoint, const String& jsonBody, 
   
   //HTTP PATCHリクエストの共通処理
   String httpPatchJson(MyApi& api, const String& endpoint, const String& jsonBody, const String& token) {
-    WiFiClientSecure client;
+    //WiFiClientSecure client;
     client.setInsecure();
     HTTPClient http;
     String payload;
     String url = api.getBaseUrl() + endpoint;
     if (!http.begin(client, url)) {
+      http.setTimeout(20000);
         payload = "[HTTP] Unable to connect " + url;
     }
+    http.setTimeout(20000);
   
     // ヘッダを付加
     http.addHeader("Content-Type", "application/json");

--- a/src/services/transcription/whisper_client.cpp
+++ b/src/services/transcription/whisper_client.cpp
@@ -185,11 +185,13 @@ void writeWavHeader(File file, int sampleRate, int bitsPerSample, int numChannel
 
 
 void transcribeAudio() {
-    File recordingFile = SD.open("/recording.wav", FILE_READ);
+    //File recordingFile = SD.open("/recording.wav", FILE_READ);
+    /*
     if (!recordingFile) {
         Serial.println("録音ファイルを開けませんでした");
         return;
     }
+    */
 
     if (recorder.isRecording()) {
         Serial.println("task1 isRecording: reading from ring buffer");
@@ -217,7 +219,7 @@ void transcribeAudio() {
         }
         Serial.println("open SD");
         SD.remove("/recording.wav");
-        recordingFile = SD.open("/recording.wav", FILE_WRITE);
+        File recordingFile = SD.open("/recording.wav", FILE_WRITE);
         writeWavHeader(recordingFile, 16000, 16, 1);
         recordingFile.write(recorder.gettempBuffer(), available);
         updateWavHeader(recordingFile);
@@ -225,7 +227,7 @@ void transcribeAudio() {
         recordingFile.close();
     }
     Serial.println("complete reccording.wav");
-    recordingFile = SD.open("/recording.wav", FILE_READ);
+    File recordingFile = SD.open("/recording.wav", FILE_READ);
     Serial.println("open SDcard for Reading");
 
 


### PR DESCRIPTION
## 概要


## 関連タスク
Close #122  (required)

## やったこと
WificlientSecure clientを統一化
無駄なSDカードのopenをなくして、止まってしまわないようにした

## やらないこと


## レビュー事項
-

## 補足 参考情報


