### PR TITLE
TRANSCRIPTIONを戻るボタンの遷移から排除

### DIFF
--- a/src/screen_manager.cpp
+++ b/src/screen_manager.cpp
@@ -13,7 +13,7 @@ extern MyApi api;
 
 void changeScreen(Screen newScreen, bool addStuck) {
   if (appState.currentScreen != newScreen) {
-    if(addStuck){
+    if(addStuck && appState.currentScreen != TRANSCRIPTION){
       appState.screenHistory.push(appState.currentScreen);
     }
     appState.currentScreen = newScreen;


### PR DESCRIPTION
## 概要


## 関連タスク
Close #141 (required)

## やったこと
appState.currentScreenがTRANSCRIPTIONの時は画面遷移のスタックに積まないよう変更

## やらないこと


## レビュー事項
-

## 補足 参考情報


