### PR TITLE
レコーディング終了後、EXTRACTに遷移

### DIFF
--- a/src/screen_manager.cpp
+++ b/src/screen_manager.cpp
@@ -13,7 +13,7 @@ extern MyApi api;
 
 void changeScreen(Screen newScreen, bool addStuck) {
   if (appState.currentScreen != newScreen) {
-    if(addStuck){
+    if(addStuck && appState.currentScreen != TRANSCRIPTION){
       appState.screenHistory.push(appState.currentScreen);
     }
     appState.currentScreen = newScreen;

--- a/src/task_manager.cpp
+++ b/src/task_manager.cpp
@@ -51,7 +51,7 @@ void task1(void *parameter) {
         vTaskDelay(pdMS_TO_TICKS(30));
         if(!recorder->isRecording()){
             Serial.println("task1 vTaskDelete");
-            changeScreen(STANDBY);
+            changeScreen(EXTRACT);
             vTaskDelete(NULL);
         }
     }


### PR DESCRIPTION
## 概要


## 関連タスク
Close #140  (required)

## やったこと
task1で、最後のtranscribeを行った後に画面遷移。
EXTRACT画面からは戻るボタン、ホームボタン生きてます。

## やらないこと


## レビュー事項
-

## 補足 参考情報


