### PR TITLE
TRANSCRIPTION時にrecordExtractをリセット

### DIFF
--- a/src/screen_manager.cpp
+++ b/src/screen_manager.cpp
@@ -27,6 +27,7 @@ void changeScreen(Screen newScreen, bool addStuck) {
         showStandbyScreen(appState);
         break;
       case TRANSCRIPTION:
+        api.setRecordExtract(""); // 介護記録の初期化
         showTranscriptionScreen(appState);//これがレコーディングスタート関数
         break;
       case EXTRACT:{


### PR DESCRIPTION
## 概要
2回目以降だと、前回の記録が残ってしまうので、どこかでリセットしてやる必要がある

## 関連タスク
Close #148  (required)

## やったこと


## やらないこと


## レビュー事項
-

## 補足 参考情報


